### PR TITLE
make tqdm version abstract

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 description = 'A new approach for representing biological sequences'
 REQUIRED_PACKAGES = [
     'gensim==3.4.0',
-    'tqdm==4.23.4',
+    'tqdm>=2.0.0',
     'pyfasta==0.5.2'
 ]
 


### PR DESCRIPTION
At the moment, biovec pins tqdm==4.23.4, which means that pip errors are thrown when trying to install biovec alongside other 3rd party dependencies which specify different requirements e.g. tqdm>=4.3. 

When publishing a 3rd party module, it is considered best practice to define abstract requirements in setup.py instead of pinning requirements. See https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires. 

Since biovec doesn't seem to need this exact version of tqdm, I've specified a range for tqdm in setup.py that biovec should work with. 