### PR TITLE
Change from pyfasta to pyfaidx

### DIFF
--- a/biovec/utils.py
+++ b/biovec/utils.py
@@ -1,4 +1,4 @@
-from pyfasta import Fasta
+from pyfaidx import Fasta
 from tqdm import tqdm
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ description = 'A new approach for representing biological sequences'
 REQUIRED_PACKAGES = [
     'gensim==3.4.0',
     'tqdm>=2.0.0',
-    'pyfasta==0.5.2',
+    'pyfaidx==0.7.1',
     'numpy>=1.18.1'
 ]
 


### PR DESCRIPTION
`pyfasta` (https://github.com/brentp/pyfasta) has been archived and suggests the use of `pyfaidx` (https://github.com/mdshw5/pyfaidx).

Making this change resolves the following errors when trying to `import biovec`:

```
>>> import biovec
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/WS1/janeh/biovec/biovec-env/lib/python3.8/site-packages/biovec/__init__.py", line 1, in <module>
    from biovec import models
  File "/usr/WS1/janeh/biovec/biovec-env/lib/python3.8/site-packages/biovec/models/__init__.py", line 1, in <module>
    from biovec.models.prot_vec import *
  File "/usr/WS1/janeh/biovec/biovec-env/lib/python3.8/site-packages/biovec/models/prot_vec.py", line 2, in <module>
    from biovec.utils import *
  File "/usr/WS1/janeh/biovec/biovec-env/lib/python3.8/site-packages/biovec/utils.py", line 1, in <module>
    from pyfasta import Fasta
  File "/usr/WS1/janeh/biovec/biovec-env/lib/python3.8/site-packages/pyfasta/__init__.py", line 3, in <module>
    from fasta import Fasta, complement, DuplicateHeaderException
ModuleNotFoundError: No module named 'fasta'
```

This should resolve Issue #15. Thank you!